### PR TITLE
Fix incorrect 'You told <player>' message with 'tell' command.

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -193,7 +193,7 @@ void DoTell (tPlayer * p, istream & sArgs)
   p->NeedNoFlag ("gagged"); // can't if gagged
   tPlayer * ptarget = p->GetPlayer (sArgs, "Tell whom?", true);  // who
   string what = GetMessage (sArgs, "Tell " + p->playername + " what?");  // what  
-  *p << "You tell " << p->playername << ", \"" << what << "\"\n";     // confirm
+  *p << "You tell " << ptarget->playername << ", \"" << what << "\"\n";     // confirm
   *ptarget << p->playername << " tells you, \"" << what << "\"\n";    // tell them
 } // end of DoTell
 


### PR DESCRIPTION
When you issued a 'tell' command, the message you got was incorrect.  For example, if players named 'Nick' and 'Test' are playing, and Nick issues the comand

    tell test hello, tinymudserver world!

Then, Nick would see the following message:

This is obviously incorect.  This commit fixes the commands/DoTell function to display the correct message

    You tell Test, "hello, tinymudserver world!"